### PR TITLE
Imgui uilist fix

### DIFF
--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -606,9 +606,8 @@ void uilist::calc_data()
 
     calculated_menu_size = { 0.0, 0.0 };
     for( int fentry : fentries ) {
-        // this will overestimate if there are any color tags, but that never happens. probably.
         calculated_menu_size.x = std::max( calculated_menu_size.x,
-                                           ImGui::CalcTextSize( entries[fentry].txt.c_str() ).x );
+                                           ImGui::CalcTextSize( remove_color_tags( entries[fentry].txt ).c_str() ).x );
     }
     calculated_menu_size.x += ImGui::CalcTextSize( " [X] " ).x;
     calculated_menu_size.y = std::min( ImGui::GetMainViewport()->Size.y,
@@ -621,7 +620,8 @@ void uilist::calc_data()
         extra_space_right = callback->desired_extra_space_right( ) + ImGui::GetStyle().FramePadding.x;
     }
 
-    calculated_bounds.w = extra_space_left + extra_space_right + calculated_menu_size.x;
+    calculated_bounds.w = extra_space_left + extra_space_right + calculated_menu_size.x
+                          + 2 * ( ImGui::GetStyle().WindowPadding.x + ImGui::GetStyle().WindowBorderSize );
     calculated_bounds.h = ImGui::GetFrameHeightWithSpacing() + calculated_menu_size.y
                           + ( additional_lines * ImGui::GetTextLineHeightWithSpacing() );
 }


### PR DESCRIPTION
#### Summary
Bugfixes "Fix the uilist size"

#### Purpose of change

Wanted in https://github.com/CleverRaven/Cataclysm-DDA/pull/74341 and I promised it.

#### Describe the solution

1. Remove colour tags for horizontal size.
2. First calculate the size of the window by calculating the `entries`, then the `title`:
   - Move the getting of the `title` size down in code - that is most of the changes.
3. Get the size of the `title` and fold it by window size to get how many vertical lines it occupies.
4. Same as 3 for `text`
   - This is text, not title:
     - ![image](https://github.com/user-attachments/assets/b25abf60-d7ab-4775-9bf7-e2164d1a2022)



#### Describe alternatives you've considered


#### Testing

1. Master
1. Before this PR
2. After this PR
3. @db48x newest changes

Main menu load game
![image](https://github.com/user-attachments/assets/1f5d0ed3-d261-458c-b186-5640fbe88338)

![image](https://github.com/user-attachments/assets/801be8f3-ffd1-4257-875f-ace7d0d506bc)

![image](https://github.com/user-attachments/assets/eb1afd09-5ee0-46b6-8d5c-8bfd05d761af)

![image](https://github.com/user-attachments/assets/795ed6fd-5182-43ed-b004-f2dbb3c79e3d)


The main menu in-game:
![image](https://github.com/user-attachments/assets/e94fe052-16ad-4f96-9746-e8baf5634eef)

![image](https://github.com/user-attachments/assets/8829bdf8-9d7a-40c8-bc92-4d6a10ddf87e)

![image](https://github.com/user-attachments/assets/434f95dd-faa8-4918-b448-2bdccd87f042)

![image](https://github.com/user-attachments/assets/e638604b-0f09-4d1b-81e1-bbedb6b3f1a1)


And the Action menu:
![image](https://github.com/user-attachments/assets/72c8fa11-11fd-470f-bf0d-5420066d0697)

![image](https://github.com/user-attachments/assets/0c4849fd-d2e2-4d25-bfc6-2214538abcce)

![image](https://github.com/user-attachments/assets/789e9ce0-f384-4610-a78d-a32f86d6ea50)

![image](https://github.com/user-attachments/assets/09990d17-0959-4d25-965b-8c48994fcf40)


The `Choose crafter` menu in the crafting menu (it will need rework anyway, but it is better):
![image](https://github.com/user-attachments/assets/09804af2-d4b6-4672-8e24-c0d69de29eae)

![image](https://github.com/user-attachments/assets/b4e85024-f3f7-4f6f-8df5-1f38e2ccd062)

![image](https://github.com/user-attachments/assets/0b1dd269-1bfe-4e08-a152-8a68c119fde6)

![image](https://github.com/user-attachments/assets/cd23f763-0a06-437d-9289-8aeaf2ad5648)

The special drop to menu in AIM (doesn't matter, isn't worse):
![image](https://github.com/user-attachments/assets/252e6bd2-dcad-47fe-95f7-4957b1bff86f)

![image](https://github.com/user-attachments/assets/74ef22cf-ba45-4a1f-9b0e-4c9baf5aac0a)

![image](https://github.com/user-attachments/assets/a8f41073-258a-4ff1-aa4e-8a492f8aad0a)

![image](https://github.com/user-attachments/assets/90d5a11f-d941-44bf-8a9a-3af36d522fc6)
_Blue Rectangle can sometimes appear in all menus._

#### Additional context
